### PR TITLE
[Formula/NNStreamer] Add build dependency on googletest

### DIFF
--- a/Formula/googletest.rb
+++ b/Formula/googletest.rb
@@ -1,0 +1,22 @@
+class Googletest < Formula
+  desc "Google Testing and Mocking Framework"
+  homepage "https://github.com/google/googletest"
+  url "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
+  version "1.8.1"
+  sha256 "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
+
+  depends_on "pkg-config" => :build
+  depends_on "cmake" => :build
+
+  keg_only "this package is only to resolve build dependency of NNStreamer, not for system-wide dependencies"
+
+  def install
+    system "rm", "-rf", "build"
+    system "mkdir", "-p", "build"
+    Dir.chdir ("build")
+    system "cmake", "..", "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+end

--- a/Formula/nnstreamer.rb
+++ b/Formula/nnstreamer.rb
@@ -9,6 +9,7 @@ class Nnstreamer < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
+  depends_on "googletest" => :build
   depends_on "libffi"
   depends_on "glib"
   depends_on "gstreamer"
@@ -17,7 +18,7 @@ class Nnstreamer < Formula
   depends_on "numpy"
 
   def install
-	system "rm", "-rf", "build"
+    system "rm", "-rf", "build"
     system "meson", "build", "--prefix=#{prefix}", "--sysconfdir=#{prefix}/etc", "-Denable-tensorflow=false", "-Denable-tensorflow-lite=false", "-Denable-pytorch=false", "-Denable-caffe2=false"
     system "ninja", "-C", "build", "install"
   end


### PR DESCRIPTION
#### This PR is for the purpose of archiving the issues and progress only.

Related to a sub-item of https://github.com/nnsuite/nnstreamer/issues/1608
See also https://github.com/nnsuite/nnstreamer/pull/1674

In order to enable unit tests in NNStreamer, this PR adds a new formula for googletest and a build dependency on googletest to the NNStreamer formula.

Signed-off-by: Wook Song <wook16.song@samsung.com>