### PR TITLE
[Formula/NNStreamer] Deploy NNStreamer only for macOS

### DIFF
--- a/Formula/nnstreamer.rb
+++ b/Formula/nnstreamer.rb
@@ -5,6 +5,7 @@ class Nnstreamer < Formula
   version "0.3.0"
   sha256 "d56e4baa4830b544b823357f927262ac14cac5bd3363c8e428c7ed4922d7209a"
 
+  depends_on :macos
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
#### This PR is for the purpose of archiving the issues and progress only.

Related to a sub-item of https://github.com/nnsuite/nnstreamer/issues/1608

Brewed NNStreamer depends on brewed libtensorflow which is not compatible brew on Linux (a.k.a Linuxbrew). For this reason, this patch modifies the NNStreamer formula to be installed in macOS only.

Signed-off-by: Wook Song <wook16.song@samsung.com>