### PR TITLE
[CI] Append -v option to brew install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 - brew update
 
 script:
-- brew install --build-from-source ./Formula/nnstreamer.rb
+- brew install --build-from-source ./Formula/nnstreamer.rb -v


### PR DESCRIPTION
In order to find out the reason why the build is failed in CI system, this patch appends -v to the 'brew install' command in the script section of .travis.tml.

Signed-off-by: Wook Song <wook16.song@samsung.com>