### PR TITLE
[Formula/SSAT] Import the recent commit (103e4f88) on Jan, 2020

### DIFF
--- a/Formula/ssat.rb
+++ b/Formula/ssat.rb
@@ -1,9 +1,9 @@
 class Ssat < Formula
   desc "Shell Script Automated Tester (unit testing executable files)"
   homepage "https://github.com/myungjoo/SSAT"
-  url "https://github.com/nnsuite/SSAT/archive/60a2e405bdd466dcc839c90a4075a5a42c6302fe.zip"
+  url "https://github.com/myungjoo/SSAT/archive/103e4f88ac32f3fdba394fccd6007e99debac159.zip"
   version "1.0.0"
-  sha256 "2d5a6d777c20e8d795521d0f1d835ae2dfcebe5de57b28db486eb1f3adb541fe"
+  sha256 "92ebd6f644f93595b5815ecb2dd75c7cc7095b851ccea37091732c7f75a6571a"
 
   def install
     system "ln","-s","ssat.sh", "ssat"


### PR DESCRIPTION
This patch imports the recent commit (103e4f88) on Jan, 2020 from the upstream repository (https://github.com/myungjoo/SSAT).

Signed-off-by: Wook Song <wook16.song@samsung.com>